### PR TITLE
how do people still think scratch is owned by mit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is the official repo for The Scratch Channel. The Scratch Channel is an unofficial Scratch-related news site, available online at <https://thescratchchannel.vercel.app>
 
 > [!IMPORTANT]
-> We are not affiliated with Scratch, the Scratch Foundation, the LifeLong Kindergarten Group, or Massachusessets Institute of Technology. News articles here are made by volunteers, not Scratch Team members.
+> We are not affiliated with Scratch, the Scratch Foundation, the Lifelong Kindergarten Group, or Massachusetts Institute of Technology. News articles here are made by volunteers, not Scratch Team members.
 
 ## Deployment
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README disclaimer: added "the Scratch Foundation", corrected organization names/spellings (e.g., Lifelong Kindergarten, Massachusetts Institute of Technology), and adjusted ordering/capitalization for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->